### PR TITLE
fix: pin versions, CF fixes

### DIFF
--- a/00-Setup/README.md
+++ b/00-Setup/README.md
@@ -111,6 +111,7 @@ Grant IAM roles to the Service Account
 ```
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SERVICE_ACCOUNT}" --role="roles/resourcemanager.projectIamAdmin"
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SERVICE_ACCOUNT}" --role="roles/storage.admin"
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SERVICE_ACCOUNT}" --role="roles/compute.imageUser"
 ```
 
 ## 4. Prepare Terraform Credential

--- a/01-Getting-Started/main.tf
+++ b/01-Getting-Started/main.tf
@@ -18,7 +18,7 @@
  * Task 2: Initialize Terraform with google provider
  * - project: var.project_id
  * - region: var.region
- * - version: "~> 3.9.0"
+ * - version: "~> 3.39.0"
  *
  * Reference - https://www.terraform.io/docs/providers/google/index.html
  *
@@ -27,7 +27,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.9.0"
+  version = "~> 3.39.0"
 }
 */
 

--- a/02-IAM/main.tf
+++ b/02-IAM/main.tf
@@ -17,12 +17,13 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.9.0"
+  version = "~> 3.39.0"
 }
 
 /**
  * Task 1: Add IAM Role Bindings (project_iam_bindings)
-* - source: "terraform-google-modules/iam/google//modules/projects_iam"
+ * - source: "terraform-google-modules/iam/google//modules/projects_iam"
+ * - version: "~> 6.2.0"
  * - projects: [var.project_id]
  * - mode: "additive"
  * - bindings:

--- a/02-IAM/main.tf
+++ b/02-IAM/main.tf
@@ -23,7 +23,7 @@ provider "google" {
 /**
  * Task 1: Add IAM Role Bindings (project_iam_bindings)
  * - source: "terraform-google-modules/iam/google//modules/projects_iam"
- * - version: "~> 6.2.0"
+ * - version: "~> 6.3.1"
  * - projects: [var.project_id]
  * - mode: "additive"
  * - bindings:

--- a/03-Networking/iam.tf
+++ b/03-Networking/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.2.0"
+  version  = "~> 6.3.1"
   projects = [var.project_id]
   mode     = "additive"
 
@@ -34,9 +34,6 @@ module "project_iam_bindings" {
       local.iam_member,
     ]
     "roles/serviceusage.serviceUsageAdmin" = [
-      local.iam_member,
-    ]
-    "roles/storage.admin" = [
       local.iam_member,
     ]
   }

--- a/03-Networking/iam.tf
+++ b/03-Networking/iam.tf
@@ -16,6 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
+  version  = "~> 6.2.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/03-Networking/main.tf
+++ b/03-Networking/main.tf
@@ -24,7 +24,7 @@ provider "google" {
  * Task 1: Add Network ("network")
  * - source: "terraform-google-modules/network/google"
  * - version: "~> 2.5.0"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - network_name: "lab03-vpc"
  * - routing_mode: "GLOBAL"
  * - subnets:
@@ -43,7 +43,7 @@ module "network" {
  * Task 2: Add Cloud NAT Instance ("cloud_nat")
  * - source: "terraform-google-modules/cloud-nat/google"
  * - version: "~> 1.3.0"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - region: var.region
  * - create_router: true
  * - router: "lab03-router"

--- a/03-Networking/main.tf
+++ b/03-Networking/main.tf
@@ -17,12 +17,13 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.9.0"
+  version = "~> 3.39.0"
 }
 
 /**
  * Task 1: Add Network ("network")
  * - source: "terraform-google-modules/network/google"
+ * - version: "~> 2.5.0"
  * - project_id: var.project_id
  * - network_name: "lab03-vpc"
  * - routing_mode: "GLOBAL"
@@ -41,6 +42,7 @@ module "network" {
 /**
  * Task 2: Add Cloud NAT Instance ("cloud_nat")
  * - source: "terraform-google-modules/cloud-nat/google"
+ * - version: "~> 1.3.0"
  * - project_id: var.project_id
  * - region: var.region
  * - create_router: true

--- a/04-Instance-Group/iam.tf
+++ b/04-Instance-Group/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.2.0"
+  version  = "~> 6.3.1"
   projects = [var.project_id]
   mode     = "additive"
 
@@ -34,9 +34,6 @@ module "project_iam_bindings" {
       local.iam_member,
     ]
     "roles/serviceusage.serviceUsageAdmin" = [
-      local.iam_member,
-    ]
-    "roles/storage.admin" = [
       local.iam_member,
     ]
   }

--- a/04-Instance-Group/iam.tf
+++ b/04-Instance-Group/iam.tf
@@ -16,6 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
+  version  = "~> 6.2.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/04-Instance-Group/main.tf
+++ b/04-Instance-Group/main.tf
@@ -47,7 +47,7 @@ resource "" "service_account_user" {
  * Task 2: Add Instance Template ("instance_template")
  * - source: terraform-google-modules/vm/google//modules/instance_template
  * - version: "~> 4.0.0"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - subnetwork: refer to subnet created in network.tf (module.network.subnets_self_links[0])
  * - source_image_family: "debian-9"
  * - source_image_project: "debian-cloud"
@@ -68,7 +68,7 @@ module "instance_template" {
  * Task 3: Add Managed Instance Group ("managed_instance_group")
  * - source: terraform-google-modules/vm/google//modules/mig
  * - version: "~> 4.0.0"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - region: var.region
  * - target_size: 2
  * - hostname: "lab04-managed-instance"

--- a/04-Instance-Group/main.tf
+++ b/04-Instance-Group/main.tf
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.9.0"
+  version = "~> 3.39.0"
 }
 
 # This startup script creates a web server application used for testing
@@ -46,6 +46,7 @@ resource "" "service_account_user" {
 /**
  * Task 2: Add Instance Template ("instance_template")
  * - source: terraform-google-modules/vm/google//modules/instance_template
+ * - version: "~> 4.0.0"
  * - project_id: var.project_id
  * - subnetwork: refer to subnet created in network.tf (module.network.subnets_self_links[0])
  * - source_image_family: "debian-9"
@@ -66,6 +67,7 @@ module "instance_template" {
 /**
  * Task 3: Add Managed Instance Group ("managed_instance_group")
  * - source: terraform-google-modules/vm/google//modules/mig
+ * - version: "~> 4.0.0"
  * - project_id: var.project_id
  * - region: var.region
  * - target_size: 2

--- a/04-Instance-Group/main.tf
+++ b/04-Instance-Group/main.tf
@@ -27,7 +27,7 @@ data "local_file" "instance_startup_script" {
 
 resource "google_service_account" "instance_group" {
   account_id = "lab04-instance-group"
-  project    = var.project_id
+  project    = module.project_iam_bindings.projects[0]
 }
 
 /**

--- a/04-Instance-Group/network.tf
+++ b/04-Instance-Group/network.tf
@@ -16,6 +16,7 @@
 
 module "network" {
   source       = "terraform-google-modules/network/google"
+  version      = "~> 2.5.0"
   project_id   = var.project_id
   network_name = "lab04-vpc"
   routing_mode = "GLOBAL"
@@ -30,6 +31,7 @@ module "network" {
 
 module "cloud_nat" {
   source        = "terraform-google-modules/cloud-nat/google"
+  version       = "~> 1.3.0"
   project_id    = var.project_id
   region        = var.region
   create_router = true

--- a/04-Instance-Group/network.tf
+++ b/04-Instance-Group/network.tf
@@ -17,7 +17,7 @@
 module "network" {
   source       = "terraform-google-modules/network/google"
   version      = "~> 2.5.0"
-  project_id   = var.project_id
+  project_id   = module.project_iam_bindings.projects[0]
   network_name = "lab04-vpc"
   routing_mode = "GLOBAL"
   subnets = [
@@ -32,7 +32,7 @@ module "network" {
 module "cloud_nat" {
   source        = "terraform-google-modules/cloud-nat/google"
   version       = "~> 1.3.0"
-  project_id    = var.project_id
+  project_id    = module.project_iam_bindings.projects[0]
   region        = var.region
   create_router = true
   router        = "lab04-router"

--- a/05-Load-Balancer/iam.tf
+++ b/05-Load-Balancer/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.2.0"
+  version  = "~> 6.3.1"
   projects = [var.project_id]
   mode     = "additive"
 
@@ -34,9 +34,6 @@ module "project_iam_bindings" {
       local.iam_member,
     ]
     "roles/serviceusage.serviceUsageAdmin" = [
-      local.iam_member,
-    ]
-    "roles/storage.admin" = [
       local.iam_member,
     ]
   }

--- a/05-Load-Balancer/iam.tf
+++ b/05-Load-Balancer/iam.tf
@@ -16,6 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
+  version  = "~> 6.2.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/05-Load-Balancer/main.tf
+++ b/05-Load-Balancer/main.tf
@@ -24,7 +24,7 @@ provider "google" {
  * Task 1: Add a Global HTTP Load Balancer ("load_balancer")
  * - source: "GoogleCloudPlatform/lb-http/google"
  * - version: "~> 3.1.0"
- * - project: var.project_id
+ * - project: module.project_iam_bindings.projects[0]
  * - name: "lab05-http-load-balancer"
  * - firewall_networks: module.network.network_self_link
  * - target_tags: var.target_tags

--- a/05-Load-Balancer/main.tf
+++ b/05-Load-Balancer/main.tf
@@ -17,13 +17,13 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.9.0"
+  version = "~> 3.39.0"
 }
 
 /**
  * Task 1: Add a Global HTTP Load Balancer ("load_balancer")
  * - source: "GoogleCloudPlatform/lb-http/google"
- * - version: "~> 3.1"
+ * - version: "~> 3.1.0"
  * - project: var.project_id
  * - name: "lab05-http-load-balancer"
  * - firewall_networks: module.network.network_self_link

--- a/05-Load-Balancer/mig.tf
+++ b/05-Load-Balancer/mig.tf
@@ -21,7 +21,7 @@ data "local_file" "instance_startup_script" {
 
 resource "google_service_account" "instance_group" {
   account_id = "lab05-instance-group"
-  project    = var.project_id
+  project    = module.project_iam_bindings.projects[0]
 }
 
 resource "google_service_account_iam_member" "service_account_user" {

--- a/05-Load-Balancer/mig.tf
+++ b/05-Load-Balancer/mig.tf
@@ -33,7 +33,7 @@ resource "google_service_account_iam_member" "service_account_user" {
 module "instance_template" {
   source               = "terraform-google-modules/vm/google//modules/instance_template"
   version              = "~> 4.0.0"
-  project_id           = var.project_id
+  project_id           = module.project_iam_bindings.projects[0]
   subnetwork           = module.network.subnets_self_links[0]
   source_image_family  = "debian-9"
   source_image_project = "debian-cloud"
@@ -48,7 +48,7 @@ module "instance_template" {
 module "managed_instance_group" {
   source            = "terraform-google-modules/vm/google//modules/mig"
   version           = "~> 4.0.0"
-  project_id        = var.project_id
+  project_id        = module.project_iam_bindings.projects[0]
   region            = var.region
   target_size       = 2
   hostname          = "lab05-managed-instance"

--- a/05-Load-Balancer/mig.tf
+++ b/05-Load-Balancer/mig.tf
@@ -32,6 +32,7 @@ resource "google_service_account_iam_member" "service_account_user" {
 
 module "instance_template" {
   source               = "terraform-google-modules/vm/google//modules/instance_template"
+  version              = "~> 4.0.0"
   project_id           = var.project_id
   subnetwork           = module.network.subnets_self_links[0]
   source_image_family  = "debian-9"
@@ -46,6 +47,7 @@ module "instance_template" {
 
 module "managed_instance_group" {
   source            = "terraform-google-modules/vm/google//modules/mig"
+  version           = "~> 4.0.0"
   project_id        = var.project_id
   region            = var.region
   target_size       = 2

--- a/05-Load-Balancer/network.tf
+++ b/05-Load-Balancer/network.tf
@@ -16,6 +16,7 @@
 
 module "network" {
   source       = "terraform-google-modules/network/google"
+  version      = "~> 2.5.0"
   project_id   = var.project_id
   network_name = "lab05-vpc"
   routing_mode = "GLOBAL"
@@ -30,6 +31,7 @@ module "network" {
 
 module "cloud_nat" {
   source        = "terraform-google-modules/cloud-nat/google"
+  version       = "~> 1.3.0"
   project_id    = var.project_id
   region        = var.region
   create_router = true

--- a/05-Load-Balancer/network.tf
+++ b/05-Load-Balancer/network.tf
@@ -17,7 +17,7 @@
 module "network" {
   source       = "terraform-google-modules/network/google"
   version      = "~> 2.5.0"
-  project_id   = var.project_id
+  project_id   = module.project_iam_bindings.projects[0]
   network_name = "lab05-vpc"
   routing_mode = "GLOBAL"
   subnets = [
@@ -32,7 +32,7 @@ module "network" {
 module "cloud_nat" {
   source        = "terraform-google-modules/cloud-nat/google"
   version       = "~> 1.3.0"
-  project_id    = var.project_id
+  project_id    = module.project_iam_bindings.projects[0]
   region        = var.region
   create_router = true
   router        = "lab05-router"

--- a/06-Cloud-Function/iam.tf
+++ b/06-Cloud-Function/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.2.0"
+  version  = "~> 6.3.1"
   projects = [var.project_id]
   mode     = "additive"
 
@@ -34,9 +34,6 @@ module "project_iam_bindings" {
       local.iam_member,
     ]
     "roles/serviceusage.serviceUsageAdmin" = [
-      local.iam_member,
-    ]
-    "roles/storage.admin" = [
       local.iam_member,
     ]
   }

--- a/06-Cloud-Function/iam.tf
+++ b/06-Cloud-Function/iam.tf
@@ -16,6 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
+  version  = "~> 6.2.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/06-Cloud-Function/main.tf
+++ b/06-Cloud-Function/main.tf
@@ -29,7 +29,7 @@ resource "random_id" "suffix" {
  * - source: "terraform-google-modules/event-function/google"
   * - version: "~> 1.3.0"
  * - name: "lab06-cloud-function-${var.project_id}-${random_id.suffix.hex}"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - region: var.region (https://cloud.google.com/functions/docs/locations)
  * - description: "Process image in GCS bucket"
  * - entry_point: "blur_images"

--- a/06-Cloud-Function/main.tf
+++ b/06-Cloud-Function/main.tf
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.9.0"
+  version = "~> 3.39.0"
 }
 
 resource "random_id" "suffix" {
@@ -27,6 +27,7 @@ resource "random_id" "suffix" {
 /**
  * Task 1: Add Cloud Function ("image_processing_function")
  * - source: "terraform-google-modules/event-function/google"
+  * - version: "~> 1.3.0"
  * - name: "lab06-cloud-function-${var.project_id}-${random_id.suffix.hex}"
  * - project_id: var.project_id
  * - region: var.region (https://cloud.google.com/functions/docs/locations)

--- a/06-Cloud-Function/resources.tf
+++ b/06-Cloud-Function/resources.tf
@@ -76,7 +76,7 @@ resource "google_storage_bucket" "image_processed" {
 
 // Service Account for Cloud Function Runtime
 resource "google_service_account" "image_processing_gcf_sa" {
-  project      = var.project_id
+  project      = module.project_iam_bindings.projects[0]
   account_id   = "image-processing-gcf"
   display_name = "Image Processing Cloud Function Service Account"
 
@@ -91,7 +91,7 @@ resource "google_service_account_iam_member" "service_account_user" {
 
 // Grant Storage Admin role for Cloud Function Runtime Service Account
 resource "google_project_iam_member" "project" {
-  project = var.project_id
+  project = module.project_iam_bindings.projects[0]
   role    = "roles/storage.admin"
   member  = "serviceAccount:${google_service_account.image_processing_gcf_sa.email}"
 

--- a/06-Cloud-Function/resources.tf
+++ b/06-Cloud-Function/resources.tf
@@ -23,6 +23,15 @@ resource "google_project_service" "cloudfunctions_api" {
   depends_on = [module.project_iam_bindings]
 }
 
+// Enable Cloud Build API (dependency for CF): cloudbuild.googleapis.com
+resource "google_project_service" "cloudbuild_api" {
+  project            = var.project_id
+  service            = "cloudbuild.googleapis.com"
+  disable_on_destroy = false
+
+  depends_on = [module.project_iam_bindings]
+}
+
 // Enable Cloud Storage API: storage-component.googleapis.com
 resource "google_project_service" "storage_component_api" {
   project            = var.project_id
@@ -34,30 +43,32 @@ resource "google_project_service" "storage_component_api" {
 
 // GCS Bucket to upload images
 resource "google_storage_bucket" "image_upload" {
-  name               = "lab06-image-upload-${var.project_id}-${random_id.suffix.hex}"
-  project            = var.project_id
-  location           = var.region
-  storage_class      = "REGIONAL"
-  force_destroy      = true
-  bucket_policy_only = true
+  name                        = "lab06-image-upload-${var.project_id}-${random_id.suffix.hex}"
+  project                     = var.project_id
+  location                    = var.region
+  storage_class               = "REGIONAL"
+  force_destroy               = true
+  uniform_bucket_level_access = true
 
   depends_on = [
     google_project_service.cloudfunctions_api,
+    google_project_service.cloudbuild_api,
     google_project_service.storage_component_api
   ]
 }
 
 // GCS Bucket to output processed images
 resource "google_storage_bucket" "image_processed" {
-  name               = "lab06-image-processed-${var.project_id}-${random_id.suffix.hex}"
-  project            = var.project_id
-  location           = var.region
-  storage_class      = "REGIONAL"
-  force_destroy      = true
-  bucket_policy_only = true
+  name                        = "lab06-image-processed-${var.project_id}-${random_id.suffix.hex}"
+  project                     = var.project_id
+  location                    = var.region
+  storage_class               = "REGIONAL"
+  force_destroy               = true
+  uniform_bucket_level_access = true
 
   depends_on = [
     google_project_service.cloudfunctions_api,
+    google_project_service.cloudbuild_api,
     google_project_service.storage_component_api,
     google_service_account_iam_member.service_account_user
   ]

--- a/06-Cloud-Function/resources.tf
+++ b/06-Cloud-Function/resources.tf
@@ -44,7 +44,7 @@ resource "google_project_service" "storage_component_api" {
 // GCS Bucket to upload images
 resource "google_storage_bucket" "image_upload" {
   name                        = "lab06-image-upload-${var.project_id}-${random_id.suffix.hex}"
-  project                     = var.project_id
+  project                     = module.project_iam_bindings.projects[0]
   location                    = var.region
   storage_class               = "REGIONAL"
   force_destroy               = true
@@ -60,7 +60,7 @@ resource "google_storage_bucket" "image_upload" {
 // GCS Bucket to output processed images
 resource "google_storage_bucket" "image_processed" {
   name                        = "lab06-image-processed-${var.project_id}-${random_id.suffix.hex}"
-  project                     = var.project_id
+  project                     = module.project_iam_bindings.projects[0]
   location                    = var.region
   storage_class               = "REGIONAL"
   force_destroy               = true

--- a/Solutions/01-Getting-Started/main.tf
+++ b/Solutions/01-Getting-Started/main.tf
@@ -18,7 +18,7 @@
  * Task 2: Initialize Terraform with google provider
  * - project: var.project_id
  * - region: var.region
- * - version: "~> 3.9.0"
+ * - version: "~> 3.39.0"
  *
  * Reference - https://www.terraform.io/docs/providers/google/index.html
  *
@@ -26,7 +26,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.9.0"
+  version = "~> 3.39.0"
 }
 
 /**

--- a/Solutions/02-IAM/main.tf
+++ b/Solutions/02-IAM/main.tf
@@ -34,7 +34,7 @@
  */
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.2.0"
+  version  = "~> 6.3.1"
   projects = [var.project_id]
   mode     = "additive"
 
@@ -52,9 +52,6 @@ module "project_iam_bindings" {
       local.iam_member,
     ]
     "roles/serviceusage.serviceUsageAdmin" = [
-      local.iam_member,
-    ]
-    "roles/storage.admin" = [
       local.iam_member,
     ]
   }

--- a/Solutions/02-IAM/main.tf
+++ b/Solutions/02-IAM/main.tf
@@ -34,6 +34,7 @@
  */
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
+  version  = "~> 6.2.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/Solutions/02-IAM/main.tf
+++ b/Solutions/02-IAM/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  version = "~> 3.39.0"
+}
+
 /**
  * Task 1: Add IAM Role Bindings (project_iam_bindings)
  * - source: "terraform-google-modules/iam/google//modules/projects_iam"

--- a/Solutions/03-Networking/main.tf
+++ b/Solutions/03-Networking/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  version = "~> 3.39.0"
+}
+
 /**
  * Task 1: Add Network ("network")
  * - source: "terraform-google-modules/network/google"

--- a/Solutions/03-Networking/main.tf
+++ b/Solutions/03-Networking/main.tf
@@ -17,7 +17,7 @@
 /**
  * Task 1: Add Network ("network")
  * - source: "terraform-google-modules/network/google"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - network_name: "lab03-vpc"
  * - routing_mode: "GLOBAL"
  * - subnets:
@@ -30,7 +30,7 @@
  */
 module "network" {
   source       = "terraform-google-modules/network/google"
-  project_id   = var.project_id
+  project_id   = module.project_iam_bindings.projects[0]
   version      = "~> 2.5.0"
   network_name = "lab03-vpc"
   routing_mode = "GLOBAL"
@@ -46,7 +46,7 @@ module "network" {
 /**
  * Task 2: Add Cloud NAT Instance ("cloud_nat")
  * - source: "terraform-google-modules/cloud-nat/google"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - region: var.region
  * - create_router: true
  * - router: "lab03-router"
@@ -58,7 +58,7 @@ module "network" {
 module "cloud_nat" {
   source        = "terraform-google-modules/cloud-nat/google"
   version       = "~> 1.3.0"
-  project_id    = var.project_id
+  project_id    = module.project_iam_bindings.projects[0]
   region        = var.region
   create_router = true
   router        = "lab03-router"

--- a/Solutions/03-Networking/main.tf
+++ b/Solutions/03-Networking/main.tf
@@ -31,6 +31,7 @@
 module "network" {
   source       = "terraform-google-modules/network/google"
   project_id   = var.project_id
+  version      = "~> 2.5.0"
   network_name = "lab03-vpc"
   routing_mode = "GLOBAL"
   subnets = [
@@ -56,6 +57,7 @@ module "network" {
  */
 module "cloud_nat" {
   source        = "terraform-google-modules/cloud-nat/google"
+  version       = "~> 1.3.0"
   project_id    = var.project_id
   region        = var.region
   create_router = true

--- a/Solutions/04-Instance-Group/main.tf
+++ b/Solutions/04-Instance-Group/main.tf
@@ -27,7 +27,7 @@ data "local_file" "instance_startup_script" {
 
 resource "google_service_account" "instance_group" {
   account_id = "lab03-instance-group"
-  project    = var.project_id
+  project    = module.project_iam_bindings.projects[0]
 }
 
 /**

--- a/Solutions/04-Instance-Group/main.tf
+++ b/Solutions/04-Instance-Group/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  version = "~> 3.39.0"
+}
+
 # This startup script creates a web server application used for testing
 data "local_file" "instance_startup_script" {
   filename = "${path.module}/templates/startup.sh"

--- a/Solutions/04-Instance-Group/main.tf
+++ b/Solutions/04-Instance-Group/main.tf
@@ -57,6 +57,7 @@ resource "google_service_account_iam_member" "service_account_user" {
  */
 module "instance_template" {
   source               = "terraform-google-modules/vm/google//modules/instance_template"
+  version              = "~> 4.0.0"
   project_id           = var.project_id
   subnetwork           = module.network.subnets_self_links[0]
   source_image_family  = "debian-9"
@@ -86,6 +87,7 @@ module "instance_template" {
  */
 module "managed_instance_group" {
   source            = "terraform-google-modules/vm/google//modules/mig"
+  version           = "~> 4.0.0"
   project_id        = var.project_id
   region            = var.region
   target_size       = 2

--- a/Solutions/04-Instance-Group/main.tf
+++ b/Solutions/04-Instance-Group/main.tf
@@ -42,7 +42,7 @@ resource "google_service_account_iam_member" "service_account_user" {
 /**
  * Task 2: Add Instance Template ("instance_template")
  * - source: terraform-google-modules/vm/google//modules/instance_template
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - subnetwork: refer to subnet created in network.tf (module.network.subnets_self_links[0])
  * - source_image_family: "debian-9"
  * - source_image_project: "debian-cloud"
@@ -58,7 +58,7 @@ resource "google_service_account_iam_member" "service_account_user" {
 module "instance_template" {
   source               = "terraform-google-modules/vm/google//modules/instance_template"
   version              = "~> 4.0.0"
-  project_id           = var.project_id
+  project_id           = module.project_iam_bindings.projects[0]
   subnetwork           = module.network.subnets_self_links[0]
   source_image_family  = "debian-9"
   source_image_project = "debian-cloud"
@@ -73,7 +73,7 @@ module "instance_template" {
 /**
  * Task 3: Add Managed Instance Group ("managed_instance_group")
  * - source: terraform-google-modules/vm/google//modules/mig
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - region: var.region
  * - target_size: 2
  * - hostname: "lab03-managed-instance"
@@ -88,7 +88,7 @@ module "instance_template" {
 module "managed_instance_group" {
   source            = "terraform-google-modules/vm/google//modules/mig"
   version           = "~> 4.0.0"
-  project_id        = var.project_id
+  project_id        = module.project_iam_bindings.projects[0]
   region            = var.region
   target_size       = 2
   hostname          = "lab03-managed-instance"

--- a/Solutions/05-Load-Balancer/main.tf
+++ b/Solutions/05-Load-Balancer/main.tf
@@ -17,7 +17,7 @@
 /**
  * Task 1: Add a Global HTTP Load Balancer ("load_balancer")
   * - source: "GoogleCloudPlatform/lb-http/google"
- * - project: var.project_id
+ * - project: module.project_iam_bindings.projects[0]
  * - name: "lab05-http-load-balancer"
  * - firewall_networks: module.network.network_self_link
  * - target_tags: var.target_tags
@@ -57,7 +57,7 @@
 module "load_balancer" {
   source            = "GoogleCloudPlatform/lb-http/google"
   version           = "~> 3.1.0"
-  project           = var.project_id
+  project           = module.project_iam_bindings.projects[0]
   name              = "lab05-http-load-balancer"
   firewall_networks = [module.network.network_self_link]
   target_tags       = var.target_tags

--- a/Solutions/05-Load-Balancer/main.tf
+++ b/Solutions/05-Load-Balancer/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  version = "~> 3.39.0"
+}
+
 /**
  * Task 1: Add a Global HTTP Load Balancer ("load_balancer")
   * - source: "GoogleCloudPlatform/lb-http/google"

--- a/Solutions/05-Load-Balancer/main.tf
+++ b/Solutions/05-Load-Balancer/main.tf
@@ -56,7 +56,7 @@
  */
 module "load_balancer" {
   source            = "GoogleCloudPlatform/lb-http/google"
-  version           = "~> 3.1"
+  version           = "~> 3.1.0"
   project           = var.project_id
   name              = "lab05-http-load-balancer"
   firewall_networks = [module.network.network_self_link]

--- a/Solutions/06-Cloud-Function/main.tf
+++ b/Solutions/06-Cloud-Function/main.tf
@@ -45,6 +45,7 @@ resource "random_id" "suffix" {
  */
 module "image_processing_function" {
   source                = "terraform-google-modules/event-function/google"
+  version               = "~> 1.3.0"
   name                  = "lab06-cloud-function-${var.project_id}-${random_id.suffix.hex}"
   project_id            = var.project_id
   region                = var.region

--- a/Solutions/06-Cloud-Function/main.tf
+++ b/Solutions/06-Cloud-Function/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  version = "~> 3.39.0"
+}
+
 resource "random_id" "suffix" {
   byte_length = 4
 }

--- a/Solutions/06-Cloud-Function/main.tf
+++ b/Solutions/06-Cloud-Function/main.tf
@@ -22,7 +22,7 @@ resource "random_id" "suffix" {
  * Task 1: Add Cloud Function ("image_processing_function")
  * - source: "terraform-google-modules/event-function/google"
  * - name: "lab06-cloud-function-${var.project_id}-${random_id.suffix.hex}"
- * - project_id: var.project_id
+ * - project_id: module.project_iam_bindings.projects[0]
  * - region: var.region (https://cloud.google.com/functions/docs/locations)
  * - description: "Process image in GCS bucket"
  * - entry_point: "blur_images"
@@ -47,7 +47,7 @@ module "image_processing_function" {
   source                = "terraform-google-modules/event-function/google"
   version               = "~> 1.3.0"
   name                  = "lab06-cloud-function-${var.project_id}-${random_id.suffix.hex}"
-  project_id            = var.project_id
+  project_id            = module.project_iam_bindings.projects[0]
   region                = var.region
   description           = "Process image in GCS bucket"
   entry_point           = "blur_images"


### PR DESCRIPTION
Pin versions across modules, bump providers and other minor fixes while doing a run through
Other fixes:
- remove `roles/storage.admin` role being managed via IAM module as destroy will remove this and cause errors with backend 
- Adds `compute.imageUser` to `00-Setup` instructions as this will be used by data resource in the plan phase of `04`. 
- Uses new IAM module version and enforces dependency fixes #30 fixes #33 
- Align solutions to be swappable for #32 
 