### PR TITLE
fix: update modules to latest versions without max constraint

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,7 @@
 driver:
   name: "terraform"
   command_timeout: 2700
+  verify_version: false
 
 provisioner:
   name: "terraform"

--- a/01-Getting-Started/main.tf
+++ b/01-Getting-Started/main.tf
@@ -18,7 +18,7 @@
  * Task 2: Initialize Terraform with google provider
  * - project: var.project_id
  * - region: var.region
- * - version: "~> 3.39.0"
+ * - version: "~> 3.53"
  *
  * Reference - https://www.terraform.io/docs/providers/google/index.html
  *
@@ -27,7 +27,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 */
 

--- a/02-IAM/main.tf
+++ b/02-IAM/main.tf
@@ -23,7 +23,7 @@ provider "google" {
 /**
  * Task 1: Add IAM Role Bindings (project_iam_bindings)
  * - source: "terraform-google-modules/iam/google//modules/projects_iam"
- * - version: "~> 6.3.1"
+ * - version: "~> 7.1.0"
  * - projects: [var.project_id]
  * - mode: "additive"
  * - bindings:

--- a/02-IAM/main.tf
+++ b/02-IAM/main.tf
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 /**

--- a/03-Networking/iam.tf
+++ b/03-Networking/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.3.1"
+  version  = "~> 7.1.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/03-Networking/main.tf
+++ b/03-Networking/main.tf
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 /**

--- a/03-Networking/main.tf
+++ b/03-Networking/main.tf
@@ -23,7 +23,7 @@ provider "google" {
 /**
  * Task 1: Add Network ("network")
  * - source: "terraform-google-modules/network/google"
- * - version: "~> 2.5.0"
+ * - version: "~> 3.2.2"
  * - project_id: module.project_iam_bindings.projects[0]
  * - network_name: "lab03-vpc"
  * - routing_mode: "GLOBAL"

--- a/04-Instance-Group/iam.tf
+++ b/04-Instance-Group/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.3.1"
+  version  = "~> 7.1.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/04-Instance-Group/main.tf
+++ b/04-Instance-Group/main.tf
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 # This startup script creates a web server application used for testing

--- a/04-Instance-Group/main.tf
+++ b/04-Instance-Group/main.tf
@@ -46,7 +46,7 @@ resource "" "service_account_user" {
 /**
  * Task 2: Add Instance Template ("instance_template")
  * - source: terraform-google-modules/vm/google//modules/instance_template
- * - version: "~> 4.0.0"
+ * - version: "~> 6.4.0"
  * - project_id: module.project_iam_bindings.projects[0]
  * - subnetwork: refer to subnet created in network.tf (module.network.subnets_self_links[0])
  * - source_image_family: "debian-9"
@@ -67,7 +67,7 @@ module "instance_template" {
 /**
  * Task 3: Add Managed Instance Group ("managed_instance_group")
  * - source: terraform-google-modules/vm/google//modules/mig
- * - version: "~> 4.0.0"
+ * - version: "~> 6.4.0"
  * - project_id: module.project_iam_bindings.projects[0]
  * - region: var.region
  * - target_size: 2

--- a/04-Instance-Group/network.tf
+++ b/04-Instance-Group/network.tf
@@ -16,7 +16,7 @@
 
 module "network" {
   source       = "terraform-google-modules/network/google"
-  version      = "~> 2.5.0"
+  version      = "~> 3.2.2"
   project_id   = module.project_iam_bindings.projects[0]
   network_name = "lab04-vpc"
   routing_mode = "GLOBAL"

--- a/05-Load-Balancer/iam.tf
+++ b/05-Load-Balancer/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.3.1"
+  version  = "~> 7.1.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/05-Load-Balancer/main.tf
+++ b/05-Load-Balancer/main.tf
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 /**
@@ -37,6 +37,12 @@ provider "google" {
  *     - timeout_sec: null
  *     - connection_draining_timeout_sec: null
  *     - enable_cdn: null
+ *     - session_affinity: null
+ *     - security_policy: null
+ *     - affinity_cookie_ttl_sec: null
+ *     - log_config: null
+ *     - custom_request_headers: null
+ *     - iap_config: null
  *     - health_check:
  *       - request_path: "/"
  *       - port: 80
@@ -45,6 +51,7 @@ provider "google" {
  *       - healthy_threshold:   null
  *       - unhealthy_threshold: null
  *       - host:                null
+  *      - logging:             null
  *   - groups:
  *     - group: module.managed_instance_group.instance_group
  *     - balancing_mode: null

--- a/05-Load-Balancer/main.tf
+++ b/05-Load-Balancer/main.tf
@@ -23,7 +23,7 @@ provider "google" {
 /**
  * Task 1: Add a Global HTTP Load Balancer ("load_balancer")
  * - source: "GoogleCloudPlatform/lb-http/google"
- * - version: "~> 3.1.0"
+ * - version: "~> 5.0.0"
  * - project: module.project_iam_bindings.projects[0]
  * - name: "lab05-http-load-balancer"
  * - firewall_networks: module.network.network_self_link

--- a/05-Load-Balancer/main.tf
+++ b/05-Load-Balancer/main.tf
@@ -40,9 +40,14 @@ provider "google" {
  *     - session_affinity: null
  *     - security_policy: null
  *     - affinity_cookie_ttl_sec: null
- *     - log_config: null
  *     - custom_request_headers: null
- *     - iap_config: null
+ *     - log_config:
+ *       - enable: false
+ *       - sample_rate: null
+ *     - iap_config:
+ *       - enable: false
+ *       - oauth2_client_id: ""
+ *       - oauth2_client_secret: ""
  *     - health_check:
  *       - request_path: "/"
  *       - port: 80

--- a/05-Load-Balancer/mig.tf
+++ b/05-Load-Balancer/mig.tf
@@ -32,7 +32,7 @@ resource "google_service_account_iam_member" "service_account_user" {
 
 module "instance_template" {
   source               = "terraform-google-modules/vm/google//modules/instance_template"
-  version              = "~> 4.0.0"
+  version              = "~> 6.4.0"
   project_id           = module.project_iam_bindings.projects[0]
   subnetwork           = module.network.subnets_self_links[0]
   source_image_family  = "debian-9"
@@ -47,7 +47,7 @@ module "instance_template" {
 
 module "managed_instance_group" {
   source            = "terraform-google-modules/vm/google//modules/mig"
-  version           = "~> 4.0.0"
+  version           = "~> 6.4.0"
   project_id        = module.project_iam_bindings.projects[0]
   region            = var.region
   target_size       = 2

--- a/05-Load-Balancer/network.tf
+++ b/05-Load-Balancer/network.tf
@@ -16,7 +16,7 @@
 
 module "network" {
   source       = "terraform-google-modules/network/google"
-  version      = "~> 2.5.0"
+  version      = "~> 3.2.2"
   project_id   = module.project_iam_bindings.projects[0]
   network_name = "lab05-vpc"
   routing_mode = "GLOBAL"

--- a/06-Cloud-Function/iam.tf
+++ b/06-Cloud-Function/iam.tf
@@ -16,7 +16,7 @@
 
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.3.1"
+  version  = "~> 7.1.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/06-Cloud-Function/main.tf
+++ b/06-Cloud-Function/main.tf
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 resource "random_id" "suffix" {

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.15
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.14
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.15
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Solutions/01-Getting-Started/main.tf.solution
+++ b/Solutions/01-Getting-Started/main.tf.solution
@@ -18,7 +18,7 @@
  * Task 2: Initialize Terraform with google provider
  * - project: var.project_id
  * - region: var.region
- * - version: "~> 3.39.0"
+ * - version: "~> 3.53"
  *
  * Reference - https://www.terraform.io/docs/providers/google/index.html
  *
@@ -26,7 +26,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 /**

--- a/Solutions/02-IAM/main.tf.solution
+++ b/Solutions/02-IAM/main.tf.solution
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 /**

--- a/Solutions/02-IAM/main.tf.solution
+++ b/Solutions/02-IAM/main.tf.solution
@@ -40,7 +40,7 @@ provider "google" {
  */
 module "project_iam_bindings" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "~> 6.3.1"
+  version  = "~> 7.1.0"
   projects = [var.project_id]
   mode     = "additive"
 

--- a/Solutions/03-Networking/main.tf.solution
+++ b/Solutions/03-Networking/main.tf.solution
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 /**

--- a/Solutions/03-Networking/main.tf.solution
+++ b/Solutions/03-Networking/main.tf.solution
@@ -37,7 +37,7 @@ provider "google" {
 module "network" {
   source       = "terraform-google-modules/network/google"
   project_id   = module.project_iam_bindings.projects[0]
-  version      = "~> 2.5.0"
+  version      = "~> 3.2.2"
   network_name = "lab03-vpc"
   routing_mode = "GLOBAL"
   subnets = [

--- a/Solutions/04-Instance-Group/main.tf.solution
+++ b/Solutions/04-Instance-Group/main.tf.solution
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 # This startup script creates a web server application used for testing

--- a/Solutions/04-Instance-Group/main.tf.solution
+++ b/Solutions/04-Instance-Group/main.tf.solution
@@ -63,7 +63,7 @@ resource "google_service_account_iam_member" "service_account_user" {
  */
 module "instance_template" {
   source               = "terraform-google-modules/vm/google//modules/instance_template"
-  version              = "~> 4.0.0"
+  version              = "~> 6.4.0"
   project_id           = module.project_iam_bindings.projects[0]
   subnetwork           = module.network.subnets_self_links[0]
   source_image_family  = "debian-9"
@@ -93,7 +93,7 @@ module "instance_template" {
  */
 module "managed_instance_group" {
   source            = "terraform-google-modules/vm/google//modules/mig"
-  version           = "~> 4.0.0"
+  version           = "~> 6.4.0"
   project_id        = module.project_iam_bindings.projects[0]
   region            = var.region
   target_size       = 2

--- a/Solutions/05-Load-Balancer/main.tf.solution
+++ b/Solutions/05-Load-Balancer/main.tf.solution
@@ -80,9 +80,18 @@ module "load_balancer" {
       session_affinity                = null
       security_policy                 = null
       affinity_cookie_ttl_sec         = null
-      log_config                      = null
       custom_request_headers          = null
-      iap_config                      = null
+
+      log_config = {
+        enable      = false
+        sample_rate = null
+      }
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = ""
+        oauth2_client_secret = ""
+      }
 
       health_check = {
         check_interval_sec  = null

--- a/Solutions/05-Load-Balancer/main.tf.solution
+++ b/Solutions/05-Load-Balancer/main.tf.solution
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 /**
@@ -77,6 +77,12 @@ module "load_balancer" {
       timeout_sec                     = null
       connection_draining_timeout_sec = null
       enable_cdn                      = null
+      session_affinity                = null
+      security_policy                 = null
+      affinity_cookie_ttl_sec         = null
+      log_config                      = null
+      custom_request_headers          = null
+      iap_config                      = null
 
       health_check = {
         check_interval_sec  = null
@@ -86,6 +92,7 @@ module "load_balancer" {
         request_path        = "/"
         port                = 80
         host                = null
+        logging             = null
       }
 
       groups = [

--- a/Solutions/05-Load-Balancer/main.tf.solution
+++ b/Solutions/05-Load-Balancer/main.tf.solution
@@ -62,7 +62,7 @@ provider "google" {
  */
 module "load_balancer" {
   source            = "GoogleCloudPlatform/lb-http/google"
-  version           = "~> 3.1.0"
+  version           = "~> 5.0.0"
   project           = module.project_iam_bindings.projects[0]
   name              = "lab05-http-load-balancer"
   firewall_networks = [module.network.network_self_link]

--- a/Solutions/06-Cloud-Function/main.tf.solution
+++ b/Solutions/06-Cloud-Function/main.tf.solution
@@ -17,7 +17,7 @@
 provider "google" {
   project = var.project_id
   region  = var.region
-  version = "~> 3.39.0"
+  version = "~> 3.53"
 }
 
 resource "random_id" "suffix" {

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -101,6 +101,6 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.15'
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -101,6 +101,6 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.15'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.14'
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -22,4 +22,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.15'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -22,4 +22,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.15'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.14'

--- a/test/fixtures/01-Getting-Started/versions.tf
+++ b/test/fixtures/01-Getting-Started/versions.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.39.0"
+  version = "3.53"
 }
 
 provider "google-beta" {
-  version = "3.39.0"
+  version = "3.53"
 }

--- a/test/fixtures/02-IAM/versions.tf
+++ b/test/fixtures/02-IAM/versions.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.39.0"
+  version = "3.53"
 }
 
 provider "google-beta" {
-  version = "3.39.0"
+  version = "3.53"
 }

--- a/test/fixtures/03-Networking/versions.tf
+++ b/test/fixtures/03-Networking/versions.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.39.0"
+  version = "3.53"
 }
 
 provider "google-beta" {
-  version = "3.39.0"
+  version = "3.53"
 }

--- a/test/fixtures/04-Instance-Group/versions.tf
+++ b/test/fixtures/04-Instance-Group/versions.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.39.0"
+  version = "3.53"
 }
 
 provider "google-beta" {
-  version = "3.39.0"
+  version = "3.53"
 }

--- a/test/fixtures/05-Load-Balancer/versions.tf
+++ b/test/fixtures/05-Load-Balancer/versions.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.39.0"
+  version = "3.53"
 }
 
 provider "google-beta" {
-  version = "3.39.0"
+  version = "3.53"
 }

--- a/test/fixtures/06-Cloud-Function/versions.tf
+++ b/test/fixtures/06-Cloud-Function/versions.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.39.0"
+  version = "3.53"
 }
 
 provider "google-beta" {
-  version = "3.39.0"
+  version = "3.53"
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -22,11 +22,11 @@ module "training-project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"
 
-  name                 = "ci-training-${random_id.random_project_id_suffix.hex}"
-  random_project_id    = true
-  org_id               = var.org_id
-  folder_id            = var.folder_id
-  billing_account      = var.billing_account
+  name              = "ci-training-${random_id.random_project_id_suffix.hex}"
+  random_project_id = true
+  org_id            = var.org_id
+  folder_id         = var.folder_id
+  billing_account   = var.billing_account
 
   auto_create_network = true
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -20,14 +20,13 @@ resource "random_id" "random_project_id_suffix" {
 
 module "training-project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 9.1"
+  version = "~> 10.0"
 
   name                 = "ci-training-${random_id.random_project_id_suffix.hex}"
   random_project_id    = true
   org_id               = var.org_id
   folder_id            = var.folder_id
   billing_account      = var.billing_account
-  skip_gcloud_download = true
 
   auto_create_network = true
 

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,13 +15,13 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.13"
 }
 
 provider "google" {
-  version = "3.41.0"
+  version = "~> 3.41"
 }
 
 provider "google-beta" {
-  version = "3.41.0"
+  version = "~> 3.41"
 }


### PR DESCRIPTION
fixes #42 

Recently cloud shell TF was updated to 0.15.x and was blocked by max constraints on older modules