### PR TITLE
fix: Remove broken credentials.json references

### DIFF
--- a/other/terraform-codelab/lab-app/provider.tf
+++ b/other/terraform-codelab/lab-app/provider.tf
@@ -16,7 +16,6 @@
 
 provider "google" {
   project     = var.project_id
-  credentials = file("credentials.json")
 }
 terraform {
   required_providers {

--- a/other/terraform-codelab/lab-app/provider.tf
+++ b/other/terraform-codelab/lab-app/provider.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  project     = var.project_id
+  project = var.project_id
 }
 terraform {
   required_providers {

--- a/other/terraform-codelab/lab-networking/provider.tf
+++ b/other/terraform-codelab/lab-networking/provider.tf
@@ -15,5 +15,5 @@
  */
 
 provider "google" {
-  project     = var.project_id
+  project = var.project_id
 }

--- a/other/terraform-codelab/lab-networking/provider.tf
+++ b/other/terraform-codelab/lab-networking/provider.tf
@@ -16,5 +16,4 @@
 
 provider "google" {
   project     = var.project_id
-  credentials = file("credentials.json")
 }


### PR DESCRIPTION
Fix broken lint tests by removing unnecessary references.