### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/01-Getting-Started/README.md
+++ b/01-Getting-Started/README.md
@@ -1,4 +1,3 @@
-
 # Cloud Foundation Toolkit Lab - 01-Getting-Started
 Clone this repository and run locally, or use Cloud Shell to walk through the steps:
 
@@ -145,7 +144,7 @@ remote_state_bucket = gs://cft-lab-state-<YOUR_NAME>-${random_id.suffix.hex}
 Run the following to review your new Google Cloud Storage buckets Note the random string that was appended to your bucket name.
 
 ```bash
-gsutil ls
+gcloud storage ls
 ```
 
 You will see the newly created GCS bucket listed as `gs://BUCKET_NAME`

--- a/06-Cloud-Function/README.md
+++ b/06-Cloud-Function/README.md
@@ -1,4 +1,3 @@
-
 # Cloud Foundation Toolkit Lab - 06-Cloud-Function
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fcloud-foundation-training&cloudshell_git_branch=master&cloudshell_open_in_editor=main.tf&cloudshell_tutorial=README.md&cloudshell_working_dir=06-Cloud-Function)
 
@@ -91,14 +90,14 @@ Verify the **Cloud Function** is deployed successfully
 
 Under **06-Cloud-Function** folder, upload a sampe image to the upload bucket
 ```
-gsutil cp images/zombie.jpg gs://`terraform output storage_bucket_image_upload`
+gcloud storage cp images/zombie.jpg gs://`terraform output storage_bucket_image_upload`
 ```
 
 On [Google Cloud Console](https://console.cloud.google.com/), navigate to **Storage -> Browser**
 
 Locate the processed image bucket and checked processed image `zombie.jpg`
 ```bash
-gsutil ls gs://`terraform output storage_bucket_image_processed`
+gcloud storage ls gs://`terraform output storage_bucket_image_processed`
 ```
 
 You can also view the Cloud Function logs from [Google Cloud Console](https://console.cloud.google.com/), navigate to **Logging -> Logs Viewer** and select Cloud Function from the dropdown list


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
